### PR TITLE
Display the audio spectrum bars better 

### DIFF
--- a/src/tui/bars_component.h
+++ b/src/tui/bars_component.h
@@ -33,12 +33,15 @@ private:
         uint32_t extra_height;
         uint32_t bar_height;
         uint32_t width_index;
+        uint32_t height_index;
+        uint32_t inverted_height;
     };
     PaSource m_source;
 
     unsigned int m_col_height;
     unsigned int m_bars_width;
 
+    char get_bar_char(const CurrentBarData *current_bar_data, vector<double> *bars);
     char get_bar_top_char(vector<double> *bars, const CurrentBarData *current_bar_data);
     void set_spectrum_settings(const ComponentData* component_data);
     char get_bar_char_character_piece(BarCharacterPiece character_piece);


### PR DESCRIPTION
In this PR I've made displaying the spectrum bars a bit better. 

The main choice being made while working in this branch was deciding what general theme the bars have to be. And because there are some other CLI visualizers, with many awesome theme's out there, I wanted to keep the theme a bit simple. So I've decided to go for an Ascii bars theme, where characters that make up the bar are random characters. And where corners are a bit smoothed of with for example a '/' character for a left corner piece.